### PR TITLE
make get_jreleaser just work with jbang

### DIFF
--- a/get_jreleaser.java
+++ b/get_jreleaser.java
@@ -1,3 +1,4 @@
+//JAVA 11+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;


### PR DESCRIPTION
By adding //JAVA 11 you can just do `jbang https://git.io/get-jreleaser`

btw. if you made this available as https://jreleaser.org/main.java you can also just do `jbang https://jrelaser.org`