### PR TITLE
Fix slsa-build-action-path

### DIFF
--- a/.github/workflows/builder_slsa3.yml
+++ b/.github/workflows/builder_slsa3.yml
@@ -78,7 +78,7 @@ jobs:
           slsa-workflow-recipient: 'delegator_generic_slsa3.yml'
           slsa-rekor-log-public: ${{ inputs.rekor-log-public }}
           slsa-runner-label: 'ubuntu-latest'
-          slsa-build-action-path: './internal/builder/java'
+          slsa-build-action-path: './internal/builders/java'
           slsa-workflow-inputs: ${{ toJson(inputs) }}
 
   slsa-run:


### PR DESCRIPTION
The wrong build-action-path is passed on to the slsa workflow, resulting in failures when running the workflow.