### PR TITLE
Fix filename of generated slsa attestation

### DIFF
--- a/.github/workflows/builder_slsa3.yml
+++ b/.github/workflows/builder_slsa3.yml
@@ -127,7 +127,7 @@ jobs:
         with:
           arguments: |
             release --auto-config --update --skip-tag --branch ${{ inputs.branch }} --tag-name ${{ env.JRELEASER_TAG_NAME }} \
-            --update-section=ASSETS --skip-checksums --file slsa/${{ needs.slsa-run.outputs.attestations-download-name }}/*-attestation.intoto.sigstore
+            --update-section=ASSETS --skip-checksums --file slsa/${{ needs.slsa-run.outputs.attestations-download-name }}/*-attestation.intoto.build.slsa
         env:
           JRELEASER_PROJECT_VERSION: ${{ inputs.project-version }}
           JRELEASER_GITHUB_TOKEN: ${{ secrets.github-token }}


### PR DESCRIPTION
See this reference:

https://github.com/slsa-framework/slsa-github-generator/blob/v1.9.0/.github/workflows/delegator_generic_slsa3.yml#L68C53-L68C53

that was changed in this commit: https://github.com/slsa-framework/slsa-github-generator/commit/2548e763ef585810bc9befc360435325369bfc9a

With this final change my release workflow completes successfully: https://github.com/netomi/macos-notarization-service/actions/runs/7144907502