### PR TITLE
Add input type validation

### DIFF
--- a/.github/workflows/validate-action-typings.yml
+++ b/.github/workflows/validate-action-typings.yml
@@ -1,0 +1,14 @@
+name: Validate action typings
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  validate-typings:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: typesafegithub/github-actions-typing@v1

--- a/.github/workflows/validate-action-typings.yml
+++ b/.github/workflows/validate-action-typings.yml
@@ -10,5 +10,5 @@ jobs:
   validate-typings:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: typesafegithub/github-actions-typing@v1

--- a/README.adoc
+++ b/README.adoc
@@ -105,7 +105,7 @@ You may use `latest` to pull the latest stable release or +
 Defaults to the directory the calling workflow runs in.
 | setup-java        | boolean | true                    | Automatically setup a Java runtime. +
 Java runtime defaults to Zulu 17.
-| java-opts         | space separated string list |                         | Additional JVM parameters for running JReleaser
+| java-opts         | String |                         | Additional JVM parameters for running JReleaser
 |===
 
 == Environment Variables

--- a/README.adoc
+++ b/README.adoc
@@ -105,7 +105,7 @@ You may use `latest` to pull the latest stable release or +
 Defaults to the directory the calling workflow runs in.
 | setup-java        | boolean | true                    | Automatically setup a Java runtime. +
 Java runtime defaults to Zulu 17.
-| java-opts         | boolean |                         | Additional JVM parameters for running JReleaser
+| java-opts         | space separated string list |                         | Additional JVM parameters for running JReleaser
 |===
 
 == Environment Variables

--- a/action-types.yml
+++ b/action-types.yml
@@ -1,0 +1,14 @@
+inputs:
+  version:
+    type: string
+  arguments:
+    type: string
+  working-directory:
+    type: string
+  setup-java:
+    type: boolean
+  java-opts:
+    type: list
+    separator: " "
+    list-item:
+      type: string

--- a/action-types.yml
+++ b/action-types.yml
@@ -2,7 +2,10 @@ inputs:
   version:
     type: string
   arguments:
-    type: string
+    type: list
+    separator: " "
+    list-item:
+      type: string
   working-directory:
     type: string
   setup-java:


### PR DESCRIPTION
This change add a simple validation for input types, fixes the doc for one of the inputs, and allows projects using [typesafe github actions](https://typesafegithub.github.io/github-workflows-kt) to use this action.